### PR TITLE
Pass indices to equal and similar, include actualIndex/expectedIndex in diff items

### DIFF
--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -1,4 +1,4 @@
-var arrayDiff = require('arraydiff');
+var arrayDiff = require('arraydiff-papandreou');
 
 function extend(target) {
     for (var i = 1; i < arguments.length; i += 1) {

--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -16,7 +16,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
     for (var k = 0; k < actual.length; k += 1) {
         mutatedArray[k] = {
             type: 'similar',
-            value: actual[k]
+            value: actual[k],
+            actualIndex: k
         };
     }
 
@@ -28,8 +29,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
         return false;
     };
 
-    var itemsDiff = arrayDiff([].concat(actual), [].concat(expected), function (a, b) {
-        return equal(a, b) || similar(a, b);
+    var itemsDiff = arrayDiff(Array.prototype.slice.call(actual), Array.prototype.slice.call(expected), function (a, b, aIndex, bIndex) {
+        return equal(a, b, aIndex, bIndex) || similar(a, b, aIndex, bIndex);
     });
 
     var removeTable = [];
@@ -91,7 +92,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
         for (var i = 0 ; i < diffItem.values.length ; i += 1) {
             added[i] = {
                 type: 'insert',
-                value: diffItem.values[i]
+                value: diffItem.values[i],
+                expectedIndex: diffItem.index
             };
         }
         Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.index), 0].concat(added));
@@ -104,6 +106,7 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
             offset -= 1;
         } else if (type === 'similar') {
             diffItem.expected = expected[offset + index];
+            diffItem.expectedIndex = offset + index;
         }
     });
 
@@ -113,7 +116,7 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
 
     for (var i = 0, c = 0; i < Math.max(actual.length, expected.length) &&  c <= conflicts; i += 1) {
         if (
-            !equal(actual[i], expected[i]) && !similar(actual[i], expected[i])
+            !equal(actual[i], expected[i], i, i) && !similar(actual[i], expected[i], i, i)
         ) {
             c += 1;
         }
@@ -126,7 +129,9 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
             mutatedArray.push({
                 type: 'similar',
                 value: actual[j],
-                expected: expected[j]
+                expected: expected[j],
+                actualIndex: j,
+                expectedIndex: j
             });
         }
 
@@ -134,14 +139,16 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
             for (; j < Math.max(actual.length, expected.length); j += 1) {
                 mutatedArray.push({
                     type: 'insert',
-                    value: expected[j]
+                    value: expected[j],
+                    expectedIndex: j
                 });
             }
         } else {
             for (; j < Math.max(actual.length, expected.length); j += 1) {
                 mutatedArray.push({
                     type: 'remove',
-                    value: actual[j]
+                    value: actual[j],
+                    actualIndex: j
                 });
             }
         }
@@ -151,7 +158,7 @@ module.exports = function arrayChanges(actual, expected, equal, similar) {
     }
 
     mutatedArray.forEach(function (diffItem) {
-        if (diffItem.type === 'similar' && equal(diffItem.value, diffItem.expected)) {
+        if (diffItem.type === 'similar' && equal(diffItem.value, diffItem.expected, diffItem.actualIndex, diffItem.expectedIndex)) {
             diffItem.type = 'equal';
         }
     });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/unexpectedjs/array-changes",
   "dependencies": {
-    "arraydiff": "papandreou/arraydiff#feature/provideItemIndicesToEqualFn"
+    "arraydiff-papandreou": "0.1.1-patch1"
   },
   "devDependencies": {
     "browserify": "10.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/unexpectedjs/array-changes",
   "dependencies": {
-    "arraydiff": "0.1.1"
+    "arraydiff": "papandreou/arraydiff#feature/provideItemIndicesToEqualFn"
   },
   "devDependencies": {
     "browserify": "10.2.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "istanbul": "0.3.17",
     "jshint": "2.7.0",
     "mocha": "2.2.5",
-    "unexpected": "10.2.0"
+    "sinon": "1.17.2",
+    "unexpected": "10.2.0",
+    "unexpected-sinon": "8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "istanbul": "0.3.17",
     "jshint": "2.7.0",
     "mocha": "2.2.5",
-    "unexpected": "9.2.1"
+    "unexpected": "10.2.0"
   }
 }

--- a/test/arrayChanges.spec.js
+++ b/test/arrayChanges.spec.js
@@ -1,6 +1,7 @@
 /*global describe, it*/
 var arrayChanges = require('../lib/arrayChanges');
-var expect = require('unexpected');
+var expect = require('unexpected').clone().use(require('unexpected-sinon'));
+var sinon = require('sinon');
 
 function toArguments() {
     return arguments;
@@ -17,10 +18,10 @@ describe('array-changes', function () {
         expect(arrayChanges([0, 1, 2, 3], [0, 1, 2, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'equal', value: 0, expected: 0 },
-            { type: 'equal', value: 1, expected: 1 },
-            { type: 'equal', value: 2, expected: 2 },
-            { type: 'equal', value: 3, expected: 3, last: true }
+            { type: 'equal', value: 0, expected: 0, actualIndex: 0, expectedIndex: 0 },
+            { type: 'equal', value: 1, expected: 1, actualIndex: 1, expectedIndex: 1 },
+            { type: 'equal', value: 2, expected: 2, actualIndex: 2, expectedIndex: 2 },
+            { type: 'equal', value: 3, expected: 3, actualIndex: 3, expectedIndex: 3, last: true }
         ]);
     });
 
@@ -28,10 +29,10 @@ describe('array-changes', function () {
         expect(arrayChanges([0, 1, 2, 3], [0, 1, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'equal', value: 0, expected: 0 },
-            { type: 'equal', value: 1, expected: 1 },
-            { type: 'remove', value: 2 },
-            { type: 'equal', value: 3, expected: 3, last: true }
+            { type: 'equal', value: 0, expected: 0, actualIndex: 0, expectedIndex: 0 },
+            { type: 'equal', value: 1, expected: 1, actualIndex: 1, expectedIndex: 1 },
+            { type: 'remove', value: 2, actualIndex: 2 },
+            { type: 'equal', value: 3, expected: 3, actualIndex: 3, expectedIndex: 2, last: true }
         ]);
     });
 
@@ -39,7 +40,7 @@ describe('array-changes', function () {
         expect(arrayChanges([0], [], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'remove', value: 0, last: true }
+            { type: 'remove', value: 0, actualIndex: 0, last: true }
         ]);
     });
 
@@ -47,10 +48,10 @@ describe('array-changes', function () {
         expect(arrayChanges([0, 1, 3], [0, 1, 2, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'equal', value: 0, expected: 0 },
-            { type: 'equal', value: 1, expected: 1 },
-            { type: 'insert', value: 2 },
-            { type: 'equal', value: 3, last: true, expected: 3 }
+            { type: 'equal', value: 0, expected: 0, actualIndex: 0, expectedIndex: 0 },
+            { type: 'equal', value: 1, expected: 1, actualIndex: 1, expectedIndex: 1 },
+            { type: 'insert', value: 2, expectedIndex: 2 },
+            { type: 'equal', value: 3, last: true, expected: 3, actualIndex: 2, expectedIndex: 3 }
         ]);
     });
 
@@ -58,7 +59,7 @@ describe('array-changes', function () {
         expect(arrayChanges([], [0], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'insert', value: 0, last: true }
+            { type: 'insert', value: 0, expectedIndex: 0, last: true }
         ]);
     });
 
@@ -66,11 +67,11 @@ describe('array-changes', function () {
         expect(arrayChanges([1, 2, 3, 0], [0, 1, 2, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'insert', value: 0, last: false },
-            { type: 'equal', value: 1, expected: 1 },
-            { type: 'equal', value: 2, expected: 2 },
-            { type: 'equal', value: 3, expected: 3 },
-            { type: 'remove', value: 0, last: true }
+            { type: 'insert', value: 0, last: false, actualIndex: 3 },
+            { type: 'equal', value: 1, expected: 1, actualIndex: 0, expectedIndex: 1 },
+            { type: 'equal', value: 2, expected: 2, actualIndex: 1, expectedIndex: 2 },
+            { type: 'equal', value: 3, expected: 3, actualIndex: 2, expectedIndex: 3 },
+            { type: 'remove', value: 0, last: true, actualIndex: 3 }
         ]);
     });
 
@@ -78,10 +79,10 @@ describe('array-changes', function () {
         expect(arrayChanges([0, 1, 2, 3], [0, 2, 1, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'equal', value: 0, expected: 0 },
-            { type: 'similar', value: 1, expected: 2 },
-            { type: 'similar', value: 2, expected: 1 },
-            { type: 'equal', value: 3, expected: 3, last: true }
+            { type: 'equal', value: 0, expected: 0, actualIndex: 0, expectedIndex: 0 },
+            { type: 'similar', value: 1, expected: 2, actualIndex: 1, expectedIndex: 1 },
+            { type: 'similar', value: 2, expected: 1, actualIndex: 2, expectedIndex: 2 },
+            { type: 'equal', value: 3, expected: 3, actualIndex: 3, expectedIndex: 3, last: true }
         ]);
     });
 
@@ -107,44 +108,93 @@ describe('array-changes', function () {
             {
                 type: 'equal',
                 value: { type: 'dog', name: 'Fido' },
-                expected: { type: 'dog', name: 'Fido' }
+                expected: { type: 'dog', name: 'Fido' },
+                actualIndex: 0,
+                expectedIndex: 0
             },
             {
                 type: 'equal',
                 value: { type: 'dog', name: 'Teddy' },
-                expected: { type: 'dog', name: 'Teddy' }
+                expected: { type: 'dog', name: 'Teddy' },
+                actualIndex: 1,
+                expectedIndex: 1
             },
             {
                 type: 'insert',
-                value: { type: 'dog', name: 'Murphy' }
+                value: { type: 'dog', name: 'Murphy' },
+                expectedIndex: 2
             },
             {
                 type: 'similar',
                 value: { type: 'person', name: 'Sune' },
-                expected: { type: 'person', name: 'Andreas' }
+                expected: { type: 'person', name: 'Andreas' },
+                actualIndex: 2,
+                expectedIndex: 3
             },
             {
                 type: 'equal',
                 value: { type: 'dog', name: 'Charlie' },
-                expected: { type: 'dog', name: 'Charlie' }
+                expected: { type: 'dog', name: 'Charlie' },
+                actualIndex: 3,
+                expectedIndex: 4
             },
             {
                 type: 'equal',
                 value: { type: 'dog', name: 'Sam' },
                 last: true,
-                expected: { type: 'dog', name: 'Sam' }
+                expected: { type: 'dog', name: 'Sam' },
+                actualIndex: 4,
+                expectedIndex: 5
             }
         ]);
     });
 
     it('supports diffing array-like objects', function () {
-        expect(arrayChanges(toArguments(1, 2, 5), toArguments(3, 4), function (a, b) {
+        expect(arrayChanges(toArguments(1, 2, 5), toArguments(1, 3, 4), function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'insert', value: toArguments( 3, 4 ) },
-            { type: 'remove', value: 1 },
-            { type: 'similar', value: 2, expected: 4 },
-            { type: 'similar', value: 5, last: true, expected: undefined }
+            { type: 'equal', value: 1, expected: 1, actualIndex: 0, expectedIndex: 0 },
+            { type: 'similar', value: 2, expected: 3, actualIndex: 1, expectedIndex: 1 },
+            { type: 'similar', value: 5, expected: 4, actualIndex: 2, expectedIndex: 2, last: true }
+        ]);
+    });
+
+    it('passes the item indices to the equal function', function () {
+        var a = [1, 2];
+        var b = [4, 5];
+        var equal = sinon.spy(function (a, b) {
+            return a === b;
+        }).named('equal');
+        arrayChanges(a, b, equal);
+        expect(equal, 'to have calls satisfying', [
+            { args: [ 1, 4, 0, 0 ] },
+            { args: [ 1, 5, 0, 1 ] },
+            { args: [ 2, 4, 1, 0 ] },
+            { args: [ 2, 5, 1, 1 ] },
+            { args: [ 1, 4, 0, 0 ] },
+            { args: [ 2, 5, 1, 1 ] },
+            { args: [ 1, 4, 0, 0 ] },
+            { args: [ 2, 5, 1, 1 ] }
+        ]);
+    });
+
+    it('passes the item indices to the similar function', function () {
+        var a = [1, 2];
+        var b = [4, 5];
+        var equal = sinon.spy(function (a, b) {
+            return a === b;
+        }).named('equal');
+        var similar = sinon.spy(function (a, b) {
+            return a === b;
+        }).named('similar');
+        arrayChanges(a, b, equal, similar);
+        expect(similar, 'to have calls satisfying', [
+            { args: [ 1, 4, 0, 0 ] },
+            { args: [ 1, 5, 0, 1 ] },
+            { args: [ 2, 4, 1, 0 ] },
+            { args: [ 2, 5, 1, 1 ] },
+            { args: [ 1, 4, 0, 0 ] },
+            { args: [ 2, 5, 1, 1 ] }
         ]);
     });
 });


### PR DESCRIPTION
Adopted from array-changes-async/arraydiff-async.

Awaiting: https://github.com/derbyjs/arraydiff/pull/2

CC: @bruderstein