### PR TITLE
Fix diff bug

### DIFF
--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -21,6 +21,10 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         };
     }
 
+    equal = equal || function (a, b) {
+        return a === b;
+    };
+
     similar = similar || function (a, b) {
         return false;
     };
@@ -29,16 +33,21 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         return equal(a, b, aIndex, bIndex) || similar(a, b, aIndex, bIndex);
     });
 
-    var removeTable = [];
     function offsetIndex(index) {
-        return index + (removeTable[index - 1] || 0);
+        var offsetIndex = 0;
+        for (var i = 0; i < mutatedArray.length && offsetIndex < index; i += 1) {
+            if (mutatedArray[i].type !== 'remove') {
+                offsetIndex++;
+            }
+        }
+
+        return i;
     }
 
     var removes = itemsDiff.filter(function (diffItem) {
         return diffItem.type === 'remove';
     });
 
-    var removesByIndex = {};
     var removedItems = 0;
     removes.forEach(function (diffItem) {
         var removeIndex = removedItems + diffItem.index;
@@ -46,26 +55,15 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
             v.type = 'remove';
         });
         removedItems += diffItem.howMany;
-        removesByIndex[diffItem.index] = removedItems;
     });
-
-    function updateRemoveTable() {
-        removedItems = 0;
-        Array.prototype.forEach.call(actual, function (_, index) {
-            removedItems += removesByIndex[index] || 0;
-            removeTable[index] = removedItems;
-        });
-    }
-
-    updateRemoveTable();
 
     var moves = itemsDiff.filter(function (diffItem) {
         return diffItem.type === 'move';
     });
 
-    var movedItems = 0;
+
     moves.forEach(function (diffItem) {
-        var moveFromIndex = offsetIndex(diffItem.from);
+        var moveFromIndex = offsetIndex(diffItem.from + 1) - 1;
         var removed = mutatedArray.slice(moveFromIndex, diffItem.howMany + moveFromIndex);
         var added = removed.map(function (v) {
             return extend({}, v, { last: false, type: 'insert' });
@@ -73,11 +71,10 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         removed.forEach(function (v) {
             v.type = 'remove';
         });
-        Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.to), 0].concat(added));
-        movedItems += diffItem.howMany;
-        removesByIndex[diffItem.from] = movedItems;
-        updateRemoveTable();
+        var insertIndex = offsetIndex(diffItem.to)
+        Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));
     });
+
 
     var inserts = itemsDiff.filter(function (diffItem) {
         return diffItem.type === 'insert';
@@ -92,7 +89,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
                 expectedIndex: diffItem.index
             };
         }
-        Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.index), 0].concat(added));
+        var insertIndex = offsetIndex(diffItem.index)
+        Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));
     });
 
     var offset = 0;

--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -35,7 +35,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
 
     function offsetIndex(index) {
         var offsetIndex = 0;
-        for (var i = 0; i < mutatedArray.length && offsetIndex < index; i += 1) {
+        var i;
+        for (i = 0; i < mutatedArray.length && offsetIndex < index; i += 1) {
             if (mutatedArray[i].type !== 'remove') {
                 offsetIndex++;
             }
@@ -71,7 +72,7 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         removed.forEach(function (v) {
             v.type = 'remove';
         });
-        var insertIndex = offsetIndex(diffItem.to)
+        var insertIndex = offsetIndex(diffItem.to);
         Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));
     });
 
@@ -89,7 +90,7 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
                 expectedIndex: diffItem.index
             };
         }
-        var insertIndex = offsetIndex(diffItem.index)
+        var insertIndex = offsetIndex(diffItem.index);
         Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));
     });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "browserify": "13.0.0",
     "bundle-collapser": "1.2.1",
+    "chance-generators": "1.18.0",
     "coveralls": "2.11.6",
     "eslint": "2.7.0",
     "eslint-config-onelint": "1.0.2",
@@ -36,6 +37,7 @@
     "mocha": "2.3.4",
     "sinon": "1.17.2",
     "unexpected": "10.7.0",
+    "unexpected-check": "1.11.0",
     "unexpected-sinon": "10.0.0"
   }
 }

--- a/test/arrayChanges.spec.js
+++ b/test/arrayChanges.spec.js
@@ -5,7 +5,7 @@ var expect = require('unexpected').clone()
     .use(require('unexpected-check'));
 var sinon = require('sinon');
 
-var generators = require('chance-generators')
+var generators = require('chance-generators');
 
 function toArguments() {
     return arguments;
@@ -34,21 +34,21 @@ function executeDiff(changes) {
 }
 
 expect.addAssertion('<array> when diffed with <array> <assertion>', function (expect, actual, expected) {
-    expect.errorMode = 'nested'
+    expect.errorMode = 'nested';
     return expect.shift(arrayChanges(actual, expected));
 });
 
 expect.addAssertion('<array> when executing the diff <assertion>', function (expect, diff) {
-    expect.errorMode = 'nested'
-    return expect.shift(executeDiff(diff))
-})
+    expect.errorMode = 'nested';
+    return expect.shift(executeDiff(diff));
+});
 
 describe('array-changes', function () {
-    var g
+    var g;
 
     beforeEach(function () {
-        g = generators(42)
-    })
+        g = generators(42);
+    });
 
     it('returns an empty change-list when the two arrays are both empty', function () {
         expect(arrayChanges([], [], function (a, b) {
@@ -305,7 +305,7 @@ describe('array-changes', function () {
         });
     }
 
-    it('produces a valid plan', () => {
+    it('produces a valid plan', function () {
         var arrays = g.array(g.natural({ max: 10 }), g.natural({ max: 10 }));
         expect(function (actual, expected) {
             expect(
@@ -315,7 +315,7 @@ describe('array-changes', function () {
                 'when executing the diff',
                 'to equal',
                 expected
-            )
+            );
         }, 'to be valid for all', arrays, arrays);
-    })
+    });
 });

--- a/test/arrayChanges.spec.js
+++ b/test/arrayChanges.spec.js
@@ -11,6 +11,38 @@ function toArguments() {
     return arguments;
 }
 
+function executeDiff(changes) {
+    var result = [];
+
+    changes.forEach(function (item) {
+        switch (item.type) {
+        case 'moveTarget':
+        case 'insert':
+            result.push(item.value);
+            break;
+        case 'equal':
+        case 'similar':
+            if (typeof item.expected === 'number') {
+                result.push(item.expected);
+            }
+
+            break;
+        }
+    });
+
+    return result;
+}
+
+expect.addAssertion('<array> when diffed with <array> <assertion>', function (expect, actual, expected) {
+    expect.errorMode = 'nested'
+    return expect.shift(arrayChanges(actual, expected));
+});
+
+expect.addAssertion('<array> when executing the diff <assertion>', function (expect, diff) {
+    expect.errorMode = 'nested'
+    return expect.shift(executeDiff(diff))
+})
+
 describe('array-changes', function () {
     var g
 
@@ -273,36 +305,17 @@ describe('array-changes', function () {
         });
     }
 
-    function executePlan(changes) {
-        var result = [];
-
-        changes.forEach(function (item) {
-            switch (item.type) {
-            case 'moveTarget':
-            case 'insert':
-                result.push(item.value);
-                break;
-            case 'equal':
-            case 'similar':
-                if (typeof item.expected === 'number') {
-                    result.push(item.expected);
-                }
-
-                break;
-            }
-        });
-
-        return result;
-    }
-
     it('produces a valid plan', () => {
         var arrays = g.array(g.natural({ max: 10 }), g.natural({ max: 10 }));
         expect(function (actual, expected) {
-            var result = arrayChanges(actual, expected, function (a, b) {
-                return a === b;
-            });
-
-            expect([result], 'when passed as parameters to', executePlan, 'to equal', expected);
+            expect(
+                actual,
+                'when diffed with',
+                expected,
+                'when executing the diff',
+                'to equal',
+                expected
+            )
         }, 'to be valid for all', arrays, arrays);
     })
 });

--- a/test/arraydiff.spec.js
+++ b/test/arraydiff.spec.js
@@ -1,0 +1,58 @@
+var expect = require('unexpected').clone()
+    .use(require('unexpected-check'));
+var arrayDiff = require('arraydiff-papandreou')
+var generators = require('chance-generators')
+
+describe('arraydiff', () => {
+    var g
+
+    beforeEach(function () {
+        g = generators(42)
+    })
+
+    function insert(array, index, values) {
+        array.splice.apply(array, [index, 0].concat(values));
+    }
+
+    function remove(array, index, howMany) {
+        return array.splice(index, howMany);
+    }
+
+    function move(array, from, to, howMany) {
+        var values = remove(array, from, howMany);
+        insert(array, to, values);
+    }
+
+    function executePlan(before, diff) {
+        var out = before.slice();
+        for (var i = 0; i < diff.length; i++) {
+            var item = diff[i];
+            // console.log 'applying:', out, item
+            if (item.type === 'insert') {
+                insert(out, item.index, item.values);
+            } else if (item.type === 'remove') {
+                remove(out, item.index, item.howMany);
+            } else if (item.type === 'move') {
+                move(out, item.from, item.to, item.howMany);
+            }
+        }
+        return out;
+    }
+
+    it('produces a valid plan', () => {
+        var arrays = g.array(g.natural({ max: 10 }), g.natural({ max: 10 }));
+        expect(function (actual, expected) {
+            var diff = arrayDiff(actual, expected, function (a, b) {
+                return a === b;
+            });
+
+            expect(
+                [actual, diff],
+                'when passed as parameters to',
+                executePlan,
+                'to equal',
+                expected
+            );
+        }, 'to be valid for all', arrays, arrays);
+    })
+})

--- a/test/arraydiff.spec.js
+++ b/test/arraydiff.spec.js
@@ -1,14 +1,14 @@
 var expect = require('unexpected').clone()
     .use(require('unexpected-check'));
-var arrayDiff = require('arraydiff-papandreou')
-var generators = require('chance-generators')
+var arrayDiff = require('arraydiff-papandreou');
+var generators = require('chance-generators');
 
-describe('arraydiff', () => {
-    var g
+describe('arraydiff', function () {
+    var g;
 
     beforeEach(function () {
-        g = generators(42)
-    })
+        g = generators(42);
+    });
 
     function insert(array, index, values) {
         array.splice.apply(array, [index, 0].concat(values));
@@ -39,7 +39,7 @@ describe('arraydiff', () => {
         return out;
     }
 
-    it('produces a valid plan', () => {
+    it('produces a valid plan', function () {
         var arrays = g.array(g.natural({ max: 10 }), g.natural({ max: 10 }));
         expect(function (actual, expected) {
             var diff = arrayDiff(actual, expected, function (a, b) {
@@ -54,5 +54,5 @@ describe('arraydiff', () => {
                 expected
             );
         }, 'to be valid for all', arrays, arrays);
-    })
-})
+    });
+});


### PR DESCRIPTION
I was trying to optimise the remove offset calculation with a table, but it does not make sense as the table has to be recalculated for every mutation. There were some cases where I was not recalculating the table probably. 

unexpected-check thinks it is working:

![screen shot 2016-09-14 at 10 19 21](https://cloud.githubusercontent.com/assets/90802/18505056/b9774d14-7a65-11e6-9c94-9e74f90a3c1e.png)
