### PR TITLE
Allow disabling the fallback to item by item diffing (Major)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-before_install: "npm install -g npm && npm cache clean"
 script: "npm run-script travis"

--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -10,7 +10,21 @@ function extend(target) {
     return target;
 }
 
-module.exports = function arrayChanges(actual, expected, equal, similar, includeNonNumericalProperties) {
+module.exports = function arrayChanges(actual, expected, equal, similar, options) {
+    if (Array.isArray(options) || typeof options === 'boolean') {
+        throw new Error([
+            'It looks like you are using arrayChanges includeNonNumericalProperties,',
+            'the API has changed. You need to supply it as an entry to an option object:',
+            'arrayChanges(actual, expected, equal, similar, {',
+            '  includeNonNumericalProperties: ["foo", "bar"]',
+            '})'
+        ].join('\n'));
+    }
+
+    options = options || {};
+    var includeNonNumericalProperties = options.includeNonNumericalProperties;
+    var fallbackToItemByItemDiff = 'fallbackToItemByItemDiff' in options ? options.fallbackToItemByItemDiff : true;
+
     var mutatedArray = new Array(actual.length);
 
     for (var k = 0; k < actual.length; k += 1) {
@@ -109,43 +123,45 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         return item.type === 'similar' || item.type === 'moveSource' || item.type === 'moveTarget' ? conflicts : conflicts + 1;
     }, 0);
 
-    var c, i;
-    for (i = 0, c = 0; i < Math.max(actual.length, expected.length) && c <= conflicts; i += 1) {
-        if (
-            i >= actual.length || i >= expected.length || (!equal(actual[i], expected[i], i, i) && !similar(actual[i], expected[i], i, i))
-        ) {
-            c += 1;
-        }
-    }
-
-    if (c <= conflicts) {
-        mutatedArray = [];
-        var j;
-        for (j = 0; j < Math.min(actual.length, expected.length); j += 1) {
-            mutatedArray.push({
-                type: 'similar',
-                value: actual[j],
-                expected: expected[j],
-                actualIndex: j,
-                expectedIndex: j
-            });
+    if (fallbackToItemByItemDiff) {
+        var c, i;
+        for (i = 0, c = 0; i < Math.max(actual.length, expected.length) && c <= conflicts; i += 1) {
+            if (
+                i >= actual.length || i >= expected.length || (!equal(actual[i], expected[i], i, i) && !similar(actual[i], expected[i], i, i))
+            ) {
+                c += 1;
+            }
         }
 
-        if (actual.length < expected.length) {
-            for (; j < Math.max(actual.length, expected.length); j += 1) {
+        if (c <= conflicts) {
+            mutatedArray = [];
+            var j;
+            for (j = 0; j < Math.min(actual.length, expected.length); j += 1) {
                 mutatedArray.push({
-                    type: 'insert',
-                    value: expected[j],
+                    type: 'similar',
+                    value: actual[j],
+                    expected: expected[j],
+                    actualIndex: j,
                     expectedIndex: j
                 });
             }
-        } else {
-            for (; j < Math.max(actual.length, expected.length); j += 1) {
-                mutatedArray.push({
-                    type: 'remove',
-                    value: actual[j],
-                    actualIndex: j
-                });
+
+            if (actual.length < expected.length) {
+                for (; j < Math.max(actual.length, expected.length); j += 1) {
+                    mutatedArray.push({
+                        type: 'insert',
+                        value: expected[j],
+                        expectedIndex: j
+                    });
+                }
+            } else {
+                for (; j < Math.max(actual.length, expected.length); j += 1) {
+                    mutatedArray.push({
+                        type: 'remove',
+                        value: actual[j],
+                        actualIndex: j
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
I have a use-case where I need to disable the fallback to item by item diffing. In order to make that happen, I had to move the `includeNonNumericalProperties` into a option hash. 

This is a breaking change, but I added a helping error message to smooth the transition.