### PR TITLE
Expose expected value on the move target

### DIFF
--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -80,14 +80,14 @@ module.exports = function arrayChanges(actual, expected, equal, similar, options
     moves.forEach(function (diffItem) {
         var moveFromIndex = offsetIndex(diffItem.from + 1) - 1;
         var removed = mutatedArray.slice(moveFromIndex, diffItem.howMany + moveFromIndex);
-        var added = removed.map(function (v) {
-            return extend({}, v, { last: false, type: 'moveTarget' });
-        });
         removed.forEach(function (v, index) {
             v.type = 'moveSource';
             v.expectedIndex = offsetIndex(diffItem.to + index);
             v.expected = expected[v.expectedIndex];
             v.equal = equal(v.value, v.expected);
+        });
+        var added = removed.map(function (v, index) {
+            return extend({}, v, { last: false, type: 'moveTarget' });
         });
         var insertIndex = offsetIndex(diffItem.to);
         Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));

--- a/test/arrayChanges.spec.js
+++ b/test/arrayChanges.spec.js
@@ -109,7 +109,7 @@ describe('array-changes', function () {
         expect(arrayChanges([1, 2, 3, 0], [0, 1, 2, 3], function (a, b) {
             return a === b;
         }), 'to equal', [
-            { type: 'moveTarget', value: 0, actualIndex: 3, last: false },
+            { type: 'moveTarget', value: 0, actualIndex: 3, expected: 0, expectedIndex: 0, equal: true, last: false },
             { type: 'equal', value: 1, actualIndex: 0, expected: 1, expectedIndex: 1 },
             { type: 'equal', value: 2, actualIndex: 1, expected: 2, expectedIndex: 2 },
             { type: 'equal', value: 3, actualIndex: 2, expected: 3, expectedIndex: 3 },
@@ -122,7 +122,7 @@ describe('array-changes', function () {
             return a === b;
         }), 'to equal', [
             { type: 'equal', value: 0, actualIndex: 0, expected: 0, expectedIndex: 0 },
-            { type: 'moveTarget', value: 2, actualIndex: 2, last: false },
+            { type: 'moveTarget', value: 2, actualIndex: 2, expected: 2, expectedIndex: 1, equal: true, last: false },
             { type: 'equal', value: 1, actualIndex: 1, expected: 1, expectedIndex: 2 },
             { type: 'moveSource', value: 2, actualIndex: 2, expected: 2, expectedIndex: 1, equal: true },
             { type: 'equal', value: 3, actualIndex: 3, expected: 3, expectedIndex: 3, last: true }
@@ -445,7 +445,15 @@ describe('array-changes', function () {
         }, function (a, b) {
             return a.kind === b.kind;
         }), 'to equal', [
-            { type: 'moveTarget', value: { kind: 1, type: 'tag', name: 'p', children: [{ data: 'Hello world 2023', type: 'text' }], attribs: {} }, actualIndex: 1, last: false },
+            {
+                type: 'moveTarget',
+                value: { kind: 1, type: 'tag', name: 'p', children: [{ data: 'Hello world 2023', type: 'text' }], attribs: {} },
+                expected: { kind: 1, type: 'tag', name: 'p', children: [{ data: 'Hello world 2025', type: 'text' }], attribs: {} },
+                actualIndex: 1,
+                expectedIndex: 0,
+                equal: false,
+                last: false
+            },
             {
                 type: 'equal',
                 value: { kind: 0, type: 'tag', name: 'p', children: [{ data: 'A', type: 'text' }], attribs: {} },


### PR DESCRIPTION
Depending on how you want to render a diff from these changes it is useful to have the expected value on both the source and target of a move.